### PR TITLE
Save selected filters

### DIFF
--- a/app/src/main/kotlin/io/eugenethedev/taigamobile/dagger/Modules.kt
+++ b/app/src/main/kotlin/io/eugenethedev/taigamobile/dagger/Modules.kt
@@ -111,7 +111,7 @@ class DataModule {
 
     @Provides
     @Singleton
-    fun provideSession(context: Context) = Session(context)
+    fun provideSession(context: Context, moshi: Moshi) = Session(context, moshi)
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/io/eugenethedev/taigamobile/domain/entities/Filters.kt
+++ b/app/src/main/kotlin/io/eugenethedev/taigamobile/domain/entities/Filters.kt
@@ -1,5 +1,8 @@
 package io.eugenethedev.taigamobile.domain.entities
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
 data class FiltersData(
     val query: String = "",
     val assignees: List<UsersFilter> = emptyList(),
@@ -40,6 +43,7 @@ sealed interface Filter {
     val color: String?
 }
 
+@JsonClass(generateAdapter = true)
 data class StatusesFilter(
     override val id: Long,
     override val color: String,
@@ -47,6 +51,7 @@ data class StatusesFilter(
     override val count: Int
 ) : Filter
 
+@JsonClass(generateAdapter = true)
 data class UsersFilter(
     override val id: Long?,
     override val name: String,
@@ -55,6 +60,7 @@ data class UsersFilter(
     override val color: String? = null
 }
 
+@JsonClass(generateAdapter = true)
 data class RolesFilter(
     override val id: Long,
     override val name: String,
@@ -63,6 +69,7 @@ data class RolesFilter(
     override val color: String? = null
 }
 
+@JsonClass(generateAdapter = true)
 data class TagsFilter(
     override val name: String,
     override val color: String,
@@ -71,6 +78,7 @@ data class TagsFilter(
     override val id: Long? = null
 }
 
+@JsonClass(generateAdapter = true)
 data class EpicsFilter(
     override val id: Long?,
     override val name: String,

--- a/app/src/main/kotlin/io/eugenethedev/taigamobile/domain/entities/Filters.kt
+++ b/app/src/main/kotlin/io/eugenethedev/taigamobile/domain/entities/Filters.kt
@@ -31,6 +31,46 @@ data class FiltersData(
         epics = epics - other.epics.toSet()
     )
 
+    // updates current filters data using other filters data
+    // (helpful for updating already selected filters)
+    fun updateData(other: FiltersData): FiltersData {
+        fun List<UsersFilter>.updateUsers(other: List<UsersFilter>) = map { current ->
+            other.find { new -> current.id == new.id  }?.let {
+                current.copy(name = it.name, count = it.count)
+            } ?: current.copy(count = 0)
+        }
+
+        fun List<StatusesFilter>.updateStatuses(other: List<StatusesFilter>) = map { current ->
+            other.find { new -> current.id == new.id  }?.let {
+                current.copy(name = it.name, color = it.color, count = it.count)
+            } ?: current.copy(count = 0)
+        }
+
+        return FiltersData(
+            assignees = assignees.updateUsers(other.assignees),
+            roles = roles.map { current ->
+                other.roles.find { new -> current.id == new.id  }?.let {
+                    current.copy(name = it.name, count = it.count)
+                } ?: current.copy(count = 0)
+            },
+            tags = tags.map { current ->
+                other.tags.find { new -> current.name == new.name  }?.let {
+                    current.copy(color = it.color, count = it.count)
+                } ?: current.copy(count = 0)
+            },
+            statuses = statuses.updateStatuses(other.statuses),
+            createdBy = createdBy.updateUsers(other.createdBy),
+            epics = epics.map { current ->
+                other.epics.find { new -> current.id == new.id  }?.let {
+                    current.copy(name = it.name, count = it.count)
+                } ?: current.copy(count = 0)
+            },
+            priorities = priorities.updateStatuses(other.priorities),
+            severities = severities.updateStatuses(other.severities),
+            types = types.updateStatuses(other.types)
+        )
+    }
+
     val filtersNumber = listOf(assignees, roles, tags, statuses, createdBy, priorities, severities, types, epics).sumOf { it.size }
 }
 

--- a/app/src/main/kotlin/io/eugenethedev/taigamobile/state/Session.kt
+++ b/app/src/main/kotlin/io/eugenethedev/taigamobile/state/Session.kt
@@ -2,6 +2,9 @@ package io.eugenethedev.taigamobile.state
 
 import android.content.Context
 import androidx.core.content.edit
+import com.squareup.moshi.Moshi
+import io.eugenethedev.taigamobile.domain.entities.FiltersData
+import io.eugenethedev.taigamobile.domain.entities.FiltersDataJsonAdapter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -11,7 +14,7 @@ import kotlinx.coroutines.launch
 /**
  * Global app state
  */
-class Session(context: Context) {
+class Session(context: Context, moshi: Moshi) {
 
     private val sharedPreferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
@@ -58,6 +61,8 @@ class Session(context: Context) {
         }
         _currentProjectId.value = id
         _currentProjectName.value = name
+
+        resetFilters()
     }
 
     private fun checkLogged(token: String, refresh: String) = listOf(token, refresh).all { it.isNotEmpty() }
@@ -68,11 +73,52 @@ class Session(context: Context) {
     val isProjectSelected = currentProjectId.map(::checkProjectSelected)
         .stateIn(scope, SharingStarted.Eagerly, initialValue = checkProjectSelected(currentProjectId.value))
 
+
+    // Filters
+    private val filtersJsonAdapter = FiltersDataJsonAdapter(moshi)
+    private fun getFiltersOrEmpty(key: String) = sharedPreferences.getString(key, null)?.let { filtersJsonAdapter.fromJson(it) } ?: FiltersData()
+
+    private val _scrumFilters = MutableStateFlow(getFiltersOrEmpty(FILTERS_SCRUM))
+    val scrumFilters: StateFlow<FiltersData> = _scrumFilters
+    fun changeScrumFilters(filters: FiltersData) {
+        sharedPreferences.edit {
+            putString(FILTERS_SCRUM, filtersJsonAdapter.toJson(filters))
+        }
+        _scrumFilters.value = filters
+    }
+
+    private val _epicsFilters = MutableStateFlow(getFiltersOrEmpty(FILTERS_EPICS))
+    val epicsFilters: StateFlow<FiltersData> = _epicsFilters
+    fun changeEpicsFilters(filters: FiltersData) {
+        sharedPreferences.edit {
+            putString(FILTERS_EPICS, filtersJsonAdapter.toJson(filters))
+        }
+        _epicsFilters.value = filters
+    }
+
+    private val _issuesFilters = MutableStateFlow(getFiltersOrEmpty(FILTERS_ISSUES))
+    val issuesFilters: StateFlow<FiltersData> = _issuesFilters
+    fun changeIssuesFilters(filters: FiltersData) {
+        sharedPreferences.edit {
+            putString(FILTERS_ISSUES, filtersJsonAdapter.toJson(filters))
+        }
+        _issuesFilters.value = filters
+    }
+
+    private fun resetFilters() {
+        changeScrumFilters(FiltersData())
+        changeEpicsFilters(FiltersData())
+        changeIssuesFilters(FiltersData())
+    }
+
+
     fun reset() {
         changeAuthCredentials("", "")
         changeServer("")
         changeCurrentUserId(-1)
         changeCurrentProject(-1, "")
+
+        resetFilters()
     }
 
     companion object {
@@ -83,6 +129,10 @@ class Session(context: Context) {
         private const val PROJECT_NAME_KEY = "project_name"
         private const val PROJECT_ID_KEY = "project_id"
         private const val USER_ID_KEY = "user_id"
+
+        private const val FILTERS_SCRUM = "filters_scrum"
+        private const val FILTERS_EPICS = "filters_epics"
+        private const val FILTERS_ISSUES = "filters_issues"
     }
 
     // Events (no data, just dispatch update to subscribers)

--- a/app/src/main/kotlin/io/eugenethedev/taigamobile/state/Session.kt
+++ b/app/src/main/kotlin/io/eugenethedev/taigamobile/state/Session.kt
@@ -76,7 +76,7 @@ class Session(context: Context, moshi: Moshi) {
 
     // Filters
     private val filtersJsonAdapter = FiltersDataJsonAdapter(moshi)
-    private fun getFiltersOrEmpty(key: String) = sharedPreferences.getString(key, null)?.let { filtersJsonAdapter.fromJson(it) } ?: FiltersData()
+    private fun getFiltersOrEmpty(key: String) = sharedPreferences.getString(key, null)?.takeIf { it.isNotBlank() }?.let { filtersJsonAdapter.fromJson(it) } ?: FiltersData()
 
     private val _scrumFilters = MutableStateFlow(getFiltersOrEmpty(FILTERS_SCRUM))
     val scrumFilters: StateFlow<FiltersData> = _scrumFilters

--- a/app/src/main/kotlin/io/eugenethedev/taigamobile/ui/screens/epics/EpicsViewModel.kt
+++ b/app/src/main/kotlin/io/eugenethedev/taigamobile/ui/screens/epics/EpicsViewModel.kt
@@ -15,7 +15,6 @@ import io.eugenethedev.taigamobile.ui.utils.MutableResultFlow
 import io.eugenethedev.taigamobile.ui.utils.asLazyPagingItems
 import io.eugenethedev.taigamobile.ui.utils.loadOrError
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -38,6 +37,9 @@ class EpicsViewModel(appComponent: AppComponent = TaigaApp.appComponent) : ViewM
         if (!shouldReload) return
         viewModelScope.launch {
             filters.loadOrError { tasksRepository.getFiltersData(CommonTaskType.Epic) }
+            filters.value.data?.let {
+                session.changeEpicsFilters(activeFilters.value.updateData(it))
+            }
         }
         shouldReload = false
     }

--- a/app/src/main/kotlin/io/eugenethedev/taigamobile/ui/screens/epics/EpicsViewModel.kt
+++ b/app/src/main/kotlin/io/eugenethedev/taigamobile/ui/screens/epics/EpicsViewModel.kt
@@ -43,7 +43,7 @@ class EpicsViewModel(appComponent: AppComponent = TaigaApp.appComponent) : ViewM
     }
 
     val filters = MutableResultFlow<FiltersData>()
-    val activeFilters = MutableStateFlow(FiltersData())
+    val activeFilters by lazy { session.epicsFilters }
     @OptIn(ExperimentalCoroutinesApi::class)
     val epics by lazy {
         activeFilters.flatMapLatest { filters ->
@@ -54,12 +54,11 @@ class EpicsViewModel(appComponent: AppComponent = TaigaApp.appComponent) : ViewM
     }
 
     fun selectFilters(filters: FiltersData) {
-        activeFilters.value = filters
+        session.changeEpicsFilters(filters)
     }
 
     init {
         session.currentProjectId.onEach {
-            activeFilters.value = FiltersData()
             epics.refresh()
             shouldReload = true
         }.launchIn(viewModelScope)

--- a/app/src/main/kotlin/io/eugenethedev/taigamobile/ui/screens/issues/IssuesViewModel.kt
+++ b/app/src/main/kotlin/io/eugenethedev/taigamobile/ui/screens/issues/IssuesViewModel.kt
@@ -44,7 +44,7 @@ class IssuesViewModel(appComponent: AppComponent = TaigaApp.appComponent) : View
     }
 
     val filters = MutableResultFlow<FiltersData>()
-    val activeFilters = MutableStateFlow(FiltersData())
+    val activeFilters by lazy { session.issuesFilters }
     @OptIn(ExperimentalCoroutinesApi::class)
     val issues by lazy {
         activeFilters.flatMapLatest { filters ->
@@ -55,12 +55,11 @@ class IssuesViewModel(appComponent: AppComponent = TaigaApp.appComponent) : View
     }
 
     fun selectFilters(filters: FiltersData) {
-        activeFilters.value = filters
+        session.changeIssuesFilters(filters)
     }
     
     init {
         session.currentProjectId.onEach {
-            activeFilters.value = FiltersData()
             shouldReload = true
         }.launchIn(viewModelScope)
 

--- a/app/src/main/kotlin/io/eugenethedev/taigamobile/ui/screens/issues/IssuesViewModel.kt
+++ b/app/src/main/kotlin/io/eugenethedev/taigamobile/ui/screens/issues/IssuesViewModel.kt
@@ -16,7 +16,6 @@ import io.eugenethedev.taigamobile.ui.utils.MutableResultFlow
 import io.eugenethedev.taigamobile.ui.utils.asLazyPagingItems
 import io.eugenethedev.taigamobile.ui.utils.loadOrError
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -39,6 +38,9 @@ class IssuesViewModel(appComponent: AppComponent = TaigaApp.appComponent) : View
         if (!shouldReload) return
         viewModelScope.launch {
             filters.loadOrError { tasksRepository.getFiltersData(CommonTaskType.Issue) }
+            filters.value.data?.let {
+                session.changeIssuesFilters(activeFilters.value.updateData(it))
+            }
         }
         shouldReload = false
     }

--- a/app/src/main/kotlin/io/eugenethedev/taigamobile/ui/screens/scrum/ScrumViewModel.kt
+++ b/app/src/main/kotlin/io/eugenethedev/taigamobile/ui/screens/scrum/ScrumViewModel.kt
@@ -45,6 +45,10 @@ class ScrumViewModel(appComponent: AppComponent = TaigaApp.appComponent) : ViewM
                     isCommonTaskFromBacklog = true
                 )
             }
+
+            filters.value.data?.let {
+                session.changeScrumFilters(activeFilters.value.updateData(it))
+            }
         }
         shouldReload = false
     }

--- a/app/src/main/kotlin/io/eugenethedev/taigamobile/ui/screens/scrum/ScrumViewModel.kt
+++ b/app/src/main/kotlin/io/eugenethedev/taigamobile/ui/screens/scrum/ScrumViewModel.kt
@@ -52,7 +52,7 @@ class ScrumViewModel(appComponent: AppComponent = TaigaApp.appComponent) : ViewM
     // stories
 
     val filters = MutableResultFlow<FiltersData>()
-    val activeFilters = MutableStateFlow(FiltersData())
+    val activeFilters by lazy { session.scrumFilters }
     @OptIn(ExperimentalCoroutinesApi::class)
     val stories by lazy {
         activeFilters.flatMapLatest { filters ->
@@ -63,7 +63,7 @@ class ScrumViewModel(appComponent: AppComponent = TaigaApp.appComponent) : ViewM
     }
 
     fun selectFilters(filters: FiltersData) {
-        activeFilters.value = filters
+        session.changeScrumFilters(filters)
     }
 
     // sprints
@@ -88,7 +88,6 @@ class ScrumViewModel(appComponent: AppComponent = TaigaApp.appComponent) : ViewM
 
     init {
         session.currentProjectId.onEach {
-            activeFilters.value = FiltersData()
             createSprintResult.value = NothingResult()
             stories.refresh()
             openSprints.refresh()

--- a/app/src/sharedTest/kotlin/io/eugenethedev/taigamobile/manager/TaigaTestInstanceManager.kt
+++ b/app/src/sharedTest/kotlin/io/eugenethedev/taigamobile/manager/TaigaTestInstanceManager.kt
@@ -112,15 +112,14 @@ class TaigaTestInstanceManager(
             .build()
 
         try {
-            // healthcheck - repeatedly (max 5 times) wait for the server to warm up with 1s interval
-            repeat(5) {
+            // healthcheck - repeatedly ping server to check if it's warmed up
+            repeat(10) {
                 checkRequest.execute().let {
                     if (it.code >= 500) {
-                        println("Instance is not ready yet, waiting 1s before another try")
-                        Thread.sleep(1000)
+                        println("Instance is not ready yet, waiting 8s before another try")
+                        Thread.sleep(8000)
                     } else {
                         it.successOrThrow()
-                        return
                     }
                 }
             }

--- a/app/src/sharedTest/kotlin/io/eugenethedev/taigamobile/manager/TaigaTestInstanceManager.kt
+++ b/app/src/sharedTest/kotlin/io/eugenethedev/taigamobile/manager/TaigaTestInstanceManager.kt
@@ -112,7 +112,12 @@ class TaigaTestInstanceManager(
             .build()
 
         try {
-            return checkRequest.execute().successOrThrow()
+            // just wait for the server to actually warm up
+            while (checkRequest.execute().code >= 500) {
+                println("Instance is not ready yet, waiting 1s before another try")
+                Thread.sleep(1000)
+            }
+            checkRequest.execute().successOrThrow()
         } catch (e: ConnectException) {
             throw IllegalArgumentException("No Taiga instance is running on $baseUrl")
         }

--- a/app/src/test/kotlin/io/eugenethedev/taigamobile/repositories/BaseRepositoryTest.kt
+++ b/app/src/test/kotlin/io/eugenethedev/taigamobile/repositories/BaseRepositoryTest.kt
@@ -26,7 +26,7 @@ abstract class BaseRepositoryTest {
 
         val dataModule = DataModule() // contains methods for API configuration
 
-        mockSession = Session(ApplicationProvider.getApplicationContext()).also {
+        mockSession = Session(ApplicationProvider.getApplicationContext(), dataModule.provideMoshi()).also {
             it.changeServer(taigaManager.baseUrl)
 
             activeUser.data.apply {

--- a/app/src/test/kotlin/io/eugenethedev/taigamobile/viewmodels/BaseViewModelTest.kt
+++ b/app/src/test/kotlin/io/eugenethedev/taigamobile/viewmodels/BaseViewModelTest.kt
@@ -35,21 +35,7 @@ abstract class BaseViewModelTest {
 
     // state mocks
     private val mockContext = mockk<Context> {
-        every { getSharedPreferences(any(), any()) } returns mockk(relaxed = true) {
-            // used for filters, need to actually save strings
-            val stringPreferences = mutableMapOf<String, String>()
-
-            every { edit() } returns mockk(relaxed = true) editor@{
-                every { putString(any(), any()) } answers {
-                    stringPreferences[firstArg()] = secondArg()
-                    this@editor
-                }
-            }
-
-            every { getString(any(), any()) } answers {
-                stringPreferences[firstArg()]
-            }
-        }
+        every { getSharedPreferences(any(), any()) } returns mockk(relaxed = true)
     }
     protected val mockSession = spyk(Session(mockContext, mockAppComponent.moshi))
     protected val mockSettings = spyk(Settings(mockContext))

--- a/app/src/test/kotlin/io/eugenethedev/taigamobile/viewmodels/IssuesViewModelTest.kt
+++ b/app/src/test/kotlin/io/eugenethedev/taigamobile/viewmodels/IssuesViewModelTest.kt
@@ -24,12 +24,12 @@ class IssuesViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `test on open`(): Unit = runBlocking {
-        val mockFiltersData = mockk<FiltersData>(relaxed = true)
+        val filtersData = FiltersData()
 
-        coEvery { mockTaskRepository.getFiltersData(any()) } returns mockFiltersData
+        coEvery { mockTaskRepository.getFiltersData(any()) } returns filtersData
         viewModel.onOpen()
 
-        assertResultEquals(SuccessResult(mockFiltersData), viewModel.filters.value)
+        assertResultEquals(SuccessResult(filtersData), viewModel.filters.value)
     }
 
     @Test
@@ -42,9 +42,9 @@ class IssuesViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `test select filters`(): Unit = runBlocking {
-        val mockFiltersData = mockk<FiltersData>()
+        val filtersData = FiltersData()
 
-        viewModel.selectFilters(mockFiltersData)
+        viewModel.selectFilters(filtersData)
         assertIs<FiltersData>(viewModel.activeFilters.value)
     }
 

--- a/app/src/test/kotlin/io/eugenethedev/taigamobile/viewmodels/ScrumViewModelTest.kt
+++ b/app/src/test/kotlin/io/eugenethedev/taigamobile/viewmodels/ScrumViewModelTest.kt
@@ -9,7 +9,6 @@ import io.eugenethedev.taigamobile.viewmodels.utils.createDeniedException
 import io.eugenethedev.taigamobile.viewmodels.utils.notFoundException
 import io.eugenethedev.taigamobile.viewmodels.utils.testLazyPagingItems
 import io.mockk.coEvery
-import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import java.time.LocalDate
 import kotlin.test.BeforeTest
@@ -26,17 +25,17 @@ class ScrumViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `test on open`(): Unit = runBlocking {
-        val mockFiltersData = mockk<FiltersData>()
+        val filtersData = FiltersData()
 
-        coEvery { mockTaskRepository.getFiltersData(any()) } returns mockFiltersData
+        coEvery { mockTaskRepository.getFiltersData(any(), true) } returns filtersData
 
         viewModel.onOpen()
-        assertResultEquals(SuccessResult(mockFiltersData), viewModel.filters.value)
+        assertResultEquals(SuccessResult(filtersData), viewModel.filters.value)
     }
 
     @Test
     fun `test on open error`(): Unit = runBlocking {
-        coEvery { mockTaskRepository.getFiltersData(any()) } throws notFoundException
+        coEvery { mockTaskRepository.getFiltersData(any(), true) } throws notFoundException
 
         viewModel.onOpen()
         assertIs<ErrorResult<FiltersData>>(viewModel.filters.value)
@@ -44,9 +43,9 @@ class ScrumViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `test select filters`(): Unit = runBlocking {
-        val mockFiltersData = mockk<FiltersData>()
+        val filtersData = FiltersData()
 
-        viewModel.selectFilters(mockFiltersData)
+        viewModel.selectFilters(filtersData)
         assertIs<FiltersData>(viewModel.activeFilters.value)
     }
 

--- a/app/src/test/kotlin/io/eugenethedev/taigamobile/viewmodels/utils/TestUtils.kt
+++ b/app/src/test/kotlin/io/eugenethedev/taigamobile/viewmodels/utils/TestUtils.kt
@@ -41,7 +41,6 @@ fun <T : Any> testLazyPagingItems(
 
     coEvery(stubBlock) answers {
         pageArg().let {
-            println("First arg: $it")
             pages.subList((it - 1) * CommonPagingSource.PAGE_SIZE, min(it * CommonPagingSource.PAGE_SIZE, pages.size))
         }
     }

--- a/taiga-test-instance/clear-taiga.sh
+++ b/taiga-test-instance/clear-taiga.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 set -e
 cd "$(dirname "$0")"
-docker-compose -f docker-compose.yml down -v
+docker compose -f docker-compose.yml down -v

--- a/taiga-test-instance/launch-taiga.sh
+++ b/taiga-test-instance/launch-taiga.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 set -e
 cd "$(dirname "$0")"
-docker-compose -f docker-compose.yml up -d
+docker compose -f docker-compose.yml up -d

--- a/taiga-test-instance/stop-taiga.sh
+++ b/taiga-test-instance/stop-taiga.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 set -e
 cd "$(dirname "$0")"
-docker-compose -f docker-compose.yml stop
+docker compose -f docker-compose.yml stop


### PR DESCRIPTION
Implements saving filters mechanism which was discussed in #46:
1. Save selected filters in SharedPreferences (thus selected filters can be restored even after app restart)
2. Update selected filters data when screen is opened again and new filters information is loaded (to keep up with the actual state)